### PR TITLE
feature: support serialize and deserialize class with private member fields

### DIFF
--- a/include/seria/deserialize/mpack-inl.hpp
+++ b/include/seria/deserialize/mpack-inl.hpp
@@ -148,14 +148,16 @@ std::enable_if_t<is_object<T>::value> deserialize(T &data,
       if (member.m_default_value == nullptr) {
         throw error(member.m_key, "missing value");
       }
-
-      data.*(member.m_ptr) = *member.m_default_value;
+      
+      member.set(data, *member.m_default_value);
       return;
     }
 
     try {
       auto value_node = mpack_node_map_cstr(node, member.m_key);
-      deserialize(data.*(member.m_ptr), value_node);
+      typename std::remove_reference_t<decltype(member)>::Type tmp_val;
+      deserialize(tmp_val, value_node);
+      member.set(data, tmp_val);
     } catch (type_error &err) {
       err.add_prefix(member.m_key);
       throw err;

--- a/include/seria/deserialize/rapidjson-inl.hpp
+++ b/include/seria/deserialize/rapidjson-inl.hpp
@@ -142,12 +142,14 @@ deserialize(T &data, const rapidjson::Value &value) {
         throw error(member.m_key, "missing value");
       }
 
-      data.*(member.m_ptr) = *member.m_default_value;
+      member.set(data, *member.m_default_value);
       return;
     }
 
     try {
-      deserialize(data.*(member.m_ptr), value[member.m_key]);
+      typename std::remove_reference_t<decltype(member)>::Type tmp_val;
+      deserialize(tmp_val, value[member.m_key]);
+      member.set(data, tmp_val);
     } catch (type_error &err) {
       err.add_prefix(member.m_key);
       throw err;

--- a/include/seria/object.hpp
+++ b/include/seria/object.hpp
@@ -10,22 +10,110 @@
 
 namespace seria {
 
-template <typename Object, typename T> struct Member {
+template <typename Object, typename T> struct MemberBase {
   const char *m_key = "";
-  T Object::*m_ptr = nullptr;
   std::unique_ptr<T> m_default_value;
   using Type = T;
+
+  MemberBase(const char *key, std::unique_ptr<T> default_value)
+      : m_key(key), m_default_value(std::move(default_value)) {}
+
+  virtual T get(const Object &obj) = 0;
+  virtual void set(Object &obj, const T &new_val) = 0;
 };
+
+template <typename Object, typename T, typename R, bool is_getter_setter = true,
+          bool is_reference = true>
+struct Member;
+
+template <typename Object, typename T, typename R>
+struct Member<Object, T, R, true, true> : public MemberBase<Object, T> {
+  R (Object::*m_setter)(const T &) = nullptr;
+  T (Object::*m_getter)() const = nullptr;
+
+  using MemberBase<Object, T>::MemberBase;
+
+  Member(const char *key, R (Object::*setter)(const T &),
+         T (Object::*getter)() const, std::unique_ptr<T> default_value)
+      : MemberBase<Object, T>(key, std::move(default_value)), m_setter(setter),
+        m_getter(getter) {}
+
+  virtual T get(const Object &obj) override { return (obj.*m_getter)(); };
+  virtual void set(Object &obj, const T &new_val) override {
+    (obj.*m_setter)(new_val);
+  };
+};
+
+template <typename Object, typename T, typename R>
+struct Member<Object, T, R, true, false> : public MemberBase<Object, T> {
+  R (Object::*m_setter)(T) = nullptr;
+  T (Object::*m_getter)() const = nullptr;
+
+  using MemberBase<Object, T>::MemberBase;
+
+  Member(const char *key, R (Object::*setter)(T), T (Object::*getter)() const,
+         std::unique_ptr<T> default_value)
+      : MemberBase<Object, T>(key, std::move(default_value)), m_setter(setter),
+        m_getter(getter) {}
+
+  virtual T get(const Object &obj) override { return (obj.*m_getter)(); };
+  virtual void set(Object &obj, const T &new_val) override {
+    (obj.*m_setter)(new_val);
+  };
+};
+
+template <typename Object, typename T, typename R, bool is_reference>
+struct Member<Object, T, R, false, is_reference>
+    : public MemberBase<Object, T> {
+  T Object::*m_ptr = nullptr;
+
+  using MemberBase<Object, T>::MemberBase;
+  
+  Member(const char *key, T Object::*ptr, std::unique_ptr<T> default_value)
+      : MemberBase<Object, T>(key, std::move(default_value)), m_ptr(ptr) {}
+  
+  virtual T get(const Object &obj) override { return obj.*m_ptr; };
+  virtual void set(Object &obj, const T &new_val) override {
+    obj.*m_ptr = new_val;
+  };
+};
+
 
 template <typename Object, typename T>
 constexpr auto member(const char *key, T Object::*ptr) {
-  return Member<Object, T>{key, ptr, nullptr};
+  return Member<Object, T, void, false, false>{key, ptr, nullptr};
 }
 
 template <typename Object, typename T>
 constexpr auto member(const char *key, T Object::*ptr, T &&default_value) {
-  return Member<Object, T>{key, ptr,
-                           std::make_unique<T>(std::forward<T>(default_value))};
+  return Member<Object, T, void, false, false>{
+      key, ptr, std::make_unique<T>(std::forward<T>(default_value))};
+}
+
+template <typename Object, typename T, typename R>
+constexpr auto member(const char *key, R (Object::*setter)(const T &),
+                      T (Object::*getter)() const) {
+  return Member<Object, T, R>{key, setter, getter, nullptr};
+}
+
+template <typename Object, typename T, typename R>
+constexpr auto member(const char *key, R (Object::*setter)(T),
+                      T (Object::*getter)() const) {
+  return Member<Object, T, R, true, false>{key, setter, getter, nullptr};
+}
+
+template <typename Object, typename T, typename R>
+constexpr auto member(const char *key, R (Object::*setter)(T),
+                      T (Object::*getter)() const, T &&default_value) {
+  return Member<Object, T, R, true, false>{
+      key, setter, getter, std::make_unique<T>(std::forward<T>(default_value))};
+}
+
+template <typename Object, typename T, typename R>
+constexpr auto member(const char *key, R (Object::*setter)(const T &),
+                      T (Object::*getter)() const, T &&default_value) {
+  return Member<Object, T, R>{
+      key, setter, getter, std::make_unique<T>(std::forward<T>(default_value))};
 }
 
 template <typename T, typename TupleType> struct KeyValueRecords {

--- a/include/seria/serialize/mpack-inl.hpp
+++ b/include/seria/serialize/mpack-inl.hpp
@@ -34,7 +34,7 @@ std::enable_if_t<is_object<T>::value> serialize(const T &obj,
   static_assert(member_size != 0, "No registered members!");
 
   auto setter = [&obj, writer](auto &member) {
-    auto &field = obj.*(member.m_ptr);
+    const auto &field = member.get(obj);
     mpack_write_str(writer, member.m_key, strlen(member.m_key));
     serialize(field, writer);
   };

--- a/include/seria/serialize/rapidjson-inl.hpp
+++ b/include/seria/serialize/rapidjson-inl.hpp
@@ -71,7 +71,7 @@ serialize(const T &obj) {
   static_assert(member_size != 0, "No registered members!");
 
   auto setter = [&obj, &document, &allocator](auto &member) {
-    auto &field = obj.*(member.m_ptr);
+    const auto &field = member.get(obj);
     rapidjson::Value key(member.m_key, allocator);
     rapidjson::Value value(serialize(field).Move(), allocator);
     document.AddMember(key, value, allocator);


### PR DESCRIPTION
hi @ukabuer 
This pr is used to support support serialize and deserialize the class with private member fields.
All we need to do is just providing setter and getter function for those private member fields.
such as 

```cpp
class User {
private:
  Gender gender = Gender::Male;
public:
  int age = 1;
  double height = 180.0;
  double value = 1.0;
  
  Gender get_gender() const {return gender;}
  bool set_gender(const Gender& new_gender)  {
    gender = new_gender; 
    return gender == Gender::Male;
  }
  double get_value() const {return value;}
  void set_value(double new_value)  { value = new_value;}
  
  double get_height() const {return height;}
  void set_height(double new_value)  { height = new_value;}
};

namespace seria {
template <> auto register_object<User>() {
  return std::make_tuple(member("age", &User::age, 32),
                         member("gender", &User::set_gender,  &User::get_gender, Gender::Female),
                         member("value", &User::set_value, &User::get_value),
                         member("height", &User::set_height, &User::get_height, 175.5));
}
}
```

you can get more info from the unit test.